### PR TITLE
feat(branch-releases): Added the ability to run a release into a different branch instead of into main

### DIFF
--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -124,7 +124,7 @@ export default class Release extends Command {
                 noPush,
             );
         } else {
-            await this.runPreRelease(
+            await this.runCustomBranchRelease(
                 commitAndTagVersionFlags,
                 duringReleasePreHook,
                 noSign,
@@ -212,7 +212,7 @@ export default class Release extends Command {
         await this.pushBranches(mainBranchName, developBranchName, noPush);
     }
 
-    private async runPreRelease(
+    private async runCustomBranchRelease(
         commitAndTagVersionFlags: string[],
         duringReleasePreHook: string | undefined,
         noSign: boolean,

--- a/src/shared/helpers/sanitise-branch-name.ts
+++ b/src/shared/helpers/sanitise-branch-name.ts
@@ -3,5 +3,5 @@
  * @param branchName The branch name to sanitise.
  */
 export function sanitiseBranchName(branchName: string) {
-    return branchName.replace(/[^a-zA-Z0-9-]/g, '-');
+    return branchName.replace(/[^a-zA-Z0-9]/g, '');
 }

--- a/src/shared/helpers/sanitise-branch-name.ts
+++ b/src/shared/helpers/sanitise-branch-name.ts
@@ -1,0 +1,7 @@
+/**
+ * Takes a branch name and removes any characters that are not alphanumeric or a hyphen.
+ * @param branchName The branch name to sanitise.
+ */
+export function sanitiseBranchName(branchName: string) {
+    return branchName.replace(/[^a-zA-Z0-9-]/g, '-');
+}


### PR DESCRIPTION
# Type
- Feature

# Completed
- Added the ability to specify a target branch
- Use the target branch to create a tracking tag
- Run releases off develop into the tracking branch. This could be used for testing branches and other functionality